### PR TITLE
fix(validators): print filename on error

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -3,7 +3,6 @@ package root
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -70,12 +69,12 @@ var app = &cli.App{
 				validator := c.Context.Value("impl").(tool.Checker)
 
 				for _, f := range args.Slice() {
-					data, err := ioutil.ReadFile(f)
+					data, err := os.ReadFile(f)
 					if err != nil {
 						return err
 					}
 
-					_, err = validator.ValidateRules(data)
+					_, err = validator.ValidateRules(f, data)
 					if err != nil {
 						return cli.Exit(err, 1)
 					}

--- a/pkg/tool/common.go
+++ b/pkg/tool/common.go
@@ -27,8 +27,8 @@ type LogQL struct {
 
 type Checker interface {
 	Transform(arg string, matchers *map[string]string) (string, error)
-	ValidateRules(data []byte) (*rulefmt.RuleGroups, error)
-	ValidateConfig(filename string) (error)
+	ValidateRules(filename string, data []byte) (*rulefmt.RuleGroups, error)
+	ValidateConfig(filename string) error
 }
 
 func GetLabelMatchers(flags []string) (map[string]string, error) {

--- a/pkg/tool/logql_alert_test.go
+++ b/pkg/tool/logql_alert_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestParseLokiAlertFileSuccess(t *testing.T) {
 	p := &tool.LogQL{}
-	_, errs := p.ValidateRules(readFile(filepath.Join("testdata/loki_alerts", "basic.yaml")))
+	fp := filepath.Join("testdata/loki_alerts", "basic.yaml")
+	_, errs := p.ValidateRules(fp, readFile(fp))
 	assert.Nil(t, errs, "unexpected errors parsing file")
 }
 
@@ -31,7 +32,8 @@ func TestParseLokiAlertFileFailure(t *testing.T) {
 	p := &tool.LogQL{}
 
 	for _, c := range table {
-		_, errs := p.ValidateRules(readFile(filepath.Join("testdata/loki_alerts", c.filename)))
+		fp := filepath.Join("testdata/loki_alerts", c.filename)
+		_, errs := p.ValidateRules(fp, readFile(fp))
 		assert.NotNil(t, errs, "Expected error parsing %s but got none", c.filename)
 		assert.Contains(t, errs.Error(), c.errMsg, "Expected error for %s.", c.filename)
 	}

--- a/pkg/tool/logql_transform.go
+++ b/pkg/tool/logql_transform.go
@@ -2,26 +2,26 @@ package tool
 
 import (
 	"fmt"
-	"sort"
-
 	parser "github.com/canonical/cos-tool/pkg/logql/syntax"
 	"github.com/canonical/cos-tool/pkg/lokiruler"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
+	"sort"
 )
 
-func (p *LogQL) ValidateRules(data []byte) (*rulefmt.RuleGroups, error) {
+func (p *LogQL) ValidateRules(filename string, data []byte) (*rulefmt.RuleGroups, error) {
 	// Expose the backend parser
 	rg, errs := lokiruler.Load(data)
 
 	if len(errs) > 0 {
-		return rg, fmt.Errorf("error validating: %+v", errs)
+
+		return rg, fmt.Errorf("error validating %s: %+v", filename, errs)
 	}
 
 	return rg, nil
 }
 
-func (p *LogQL) ValidateConfig(filename string) (error) {
+func (p *LogQL) ValidateConfig(filename string) error {
 	return fmt.Errorf("Loki not supported for validate-config")
 }
 

--- a/pkg/tool/promql_alert_test.go
+++ b/pkg/tool/promql_alert_test.go
@@ -15,7 +15,8 @@ func readFile(filepath string) []byte {
 }
 func TestParsePromAlertFileSuccess(t *testing.T) {
 	p := &tool.PromQL{}
-	_, errs := p.ValidateRules(readFile(filepath.Join("testdata/prom_alerts", "basic.yaml")))
+	fp := filepath.Join("testdata/prom_alerts", "basic.yaml")
+	_, errs := p.ValidateRules(fp, readFile(fp))
 	assert.Nil(t, errs, "unexpected errors parsing file")
 }
 
@@ -37,7 +38,8 @@ func TestParsePromAlertFileFailure(t *testing.T) {
 	p := &tool.PromQL{}
 
 	for _, c := range table {
-		_, errs := p.ValidateRules(readFile(filepath.Join("testdata/prom_alerts", c.filename)))
+		fp := filepath.Join("testdata/prom_alerts", c.filename)
+		_, errs := p.ValidateRules(fp, readFile(fp))
 		assert.NotNil(t, errs, "Expected error parsing %s but got none", c.filename)
 		assert.Contains(t, errs.Error(), c.errMsg, "Expected error for %s.", c.filename)
 	}

--- a/pkg/tool/promql_transform.go
+++ b/pkg/tool/promql_transform.go
@@ -3,24 +3,24 @@ package tool
 import (
 	"fmt"
 	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/config"
 )
 
-func (p *PromQL) ValidateRules(data []byte) (*rulefmt.RuleGroups, error) {
+func (p *PromQL) ValidateRules(filename string, data []byte) (*rulefmt.RuleGroups, error) {
 	// Expose the backend parser for alert rule validation
 	rg, errs := rulefmt.Parse(data)
 
 	if len(errs) > 0 {
-		return rg, fmt.Errorf("error validating: %+v", errs[0])
+		return rg, fmt.Errorf("error validating %s: %+v", filename, errs)
 	}
 	return rg, nil
 }
 
 // This function only checks syntax. If more in depth checking is needed, it must be expanded.
-func(p *PromQL) ValidateConfig(filename string) (error) {
+func (p *PromQL) ValidateConfig(filename string) error {
 	// Assuming here that agent mode is false. If we support agent mode in the future, this needs to be revisited.
 	_, err := config.LoadFile(filename, false, false, log.NewNopLogger())
 	if err != nil {


### PR DESCRIPTION
resolves #5 

## Issue
<!-- What issue is this PR trying to solve? -->
As described in #5 

## Solution
<!-- A summary of the solution addressing the above issue -->
Print filename whenever a file fails validation.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Try the tool against the provided test data

## Release Notes
<!-- A digestable summary of the change in this PR -->
Print the filename of alert rules that fail cos-tool rule validation.