### PR TITLE
fix(ci): fix release workflow path for arm64 binary

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -41,6 +41,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: debug --snapshot
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -41,6 +41,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: --debug --snapshot
+          args: debug --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cos-tool-arm64
-          path: dist/cos-tool_linux_arm64/cos-tool
+          path: dist/cos-tool_linux_arm64_v8.0/cos-tool
 
   ghrelease:
     name: Create GitHub Release


### PR DESCRIPTION
## Issue
The upload-artifact action for the arm64 binary is [failing silently](https://github.com/canonical/cos-tool/actions/runs/12320064956/job/34388549334#step:6:12), because the path produced by goreleaser changed from

https://github.com/canonical/cos-tool/blob/05f0b819bf1d09fb1ecbdbbbe892b526c32fcc7d/.github/workflows/release.yaml#L65

to `dist/cos-tool_linux_arm64_v8.0/cos-tool` ([ref](https://github.com/canonical/cos-tool/actions/runs/12320064956/job/34388549334#step:4:38)).

## Solution
Add the `_v8.0` suffix to the workflow.


## Context
We didn't have an arm64 release since March 2024.
![image](https://github.com/user-attachments/assets/5944563e-1fa5-41e9-a008-d40d798f244b)

