### PR TITLE
Update github.com/prometheus/prometheus module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.34.0
-	github.com/prometheus/prometheus v1.8.2-0.20220406040511-1c1b174a8e98
+	github.com/prometheus/prometheus ce55e50
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.8.1


### PR DESCRIPTION
The cos-tool uses this prometheus module to validate prometheus rules. The current version does not support the field `keep_firing_for` and breaks some alert rules

## Issue
Alert rules are failing to pass to COS when using the field `keep_firing_for` as described here https://github.com/canonical/prometheus-k8s-operator/issues/746

Checking the logs of prometheus was possible to see this:

```
2025-11-17T18:08:35.454Z [container-agent] 2025-11-17 18:08:35 ERROR juju-log ingress:7: Invalid alert rule file: error validating /tmp/tmpl3xhp4er/validate_rule.yaml: [yaml: unmarshal errors:

```

## Solution
The support for that was introduced in https://github.com/prometheus/prometheus/pull/11827 which is not present in the pinned version of cos-tool. Updating the module can fix the issue.

However, I think that a good enhancement for the product is to block the Prometheus if the alert rules are not valid for some reason. The behavior now is silent and can easily not be noted and all alert rules from a charm can be missed


## Context
I do not have experience programming Go. I just updated the module to be sure that will include the necessary logic
