### PR TITLE
fix the way a context is retrieved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,19 +24,19 @@ vuln-check:
 
 build:
 	@echo "Building cos-tool..."
-	@go build -o bin/cos-tool ./cmd/root
+	@go build -o bin/cos-tool
 	@chmod +x bin/cos-tool
 
 build-all:
 	@echo "Building cos-tool for all architectures..."
 	@echo "Building for linux/amd64..."
-	GOOS=linux GOARCH=amd64 go build -o bin/cos-tool-linux-amd64 ./cmd/root
+	GOOS=linux GOARCH=amd64 go build -o bin/cos-tool-linux-amd64
 	@echo "Building for linux/arm64..."
-	GOOS=linux GOARCH=arm64 go build -o bin/cos-tool-linux-arm64 ./cmd/root
+	GOOS=linux GOARCH=arm64 go build -o bin/cos-tool-linux-arm64
 	@echo "Building for linux/ppc64le..."
-	GOOS=linux GOARCH=ppc64le go build -o bin/cos-tool-linux-ppc64le ./cmd/root
+	GOOS=linux GOARCH=ppc64le go build -o bin/cos-tool-linux-ppc64le
 	@echo "Building for linux/s390x..."
-	GOOS=linux GOARCH=s390x go build -o bin/cos-tool-linux-s390x ./cmd/root
+	GOOS=linux GOARCH=s390x go build -o bin/cos-tool-linux-s390x
 	@echo "All builds completed in bin/ directory"
 
 clean:

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -51,7 +51,7 @@ var app = &cli.App{
 					log.Fatal(err)
 				}
 
-				transformer := c.Context.Value("impl").(tool.Checker)
+				transformer := c.Context.Value(implKey).(tool.Checker)
 				output, err := transformer.Transform(args.First(), &inj)
 				if err != nil {
 					return err
@@ -71,7 +71,7 @@ var app = &cli.App{
 					log.Fatal("Expected at least one rule file to validate.")
 				}
 
-				validator := c.Context.Value("impl").(tool.Checker)
+				validator := c.Context.Value(implKey).(tool.Checker)
 
 				for _, f := range args.Slice() {
 					data, err := os.ReadFile(f)
@@ -97,7 +97,7 @@ var app = &cli.App{
 					log.Fatal("Expected at least one rule file to validate.")
 				}
 
-				validator := c.Context.Value("impl").(tool.Checker)
+				validator := c.Context.Value(implKey).(tool.Checker)
 
 				for _, f := range args.Slice() {
 					err := validator.ValidateConfig(f)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR was discovered in https://github.com/canonical/prometheus-k8s-operator/issues/759


- The code defined a custom type `contextKey` and constant `implKey` contextKey = "impl"
- Context values were being set with `implKey` (typed key)
- But retrieved with `impl` (string literal)
- In Go, these are different keys, so retrieval returned nil, causing the panic



## Solution
<!-- A summary of the solution addressing the above issue -->

Changed all three `c.Context.Value("impl")` calls to use `c.Context.Value(implKey)` to match the key type used when setting the value




## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Just run:

```shell
make test
```
